### PR TITLE
change implementation to linked list and create driver

### DIFF
--- a/Problem1/Problem1Driver.java
+++ b/Problem1/Problem1Driver.java
@@ -1,0 +1,24 @@
+/**
+ * Created by jinxters on 3/2/15.
+ */
+public class Problem1Driver {
+    public static void main(String[] args) {
+        Submission submission1 = new Submission();
+        Submission submission2 = new Submission();
+        Submission submission3 = new Submission();
+        Submission submission4 = new Submission();
+
+        SubmissionQueue queue = SubmissionQueue.getInstance();
+
+        queue.add(submission1);
+        queue.add(submission2);
+        queue.add(submission3);
+        queue.add(submission4);
+
+        queue.process();
+        queue.process();
+        queue.process();
+        queue.process();
+
+    }
+}

--- a/Problem1/Submission.java
+++ b/Problem1/Submission.java
@@ -8,13 +8,17 @@ import java.util.Random;
 
 public class Submission
 {
-  private static Random rand = new Random();
-  private int id;
+    private static Random rand = new Random();
+    private int id;
 
-  public Submission()
-  {
+    public Submission()
+    {
     // Give this submission a unique(ish) id
-    id = rand.nextInt(10000000);
-  }
+        id = rand.nextInt(10000000);
+    }
+
+    public int getId(){
+        return id;
+    }
 }
 

--- a/Problem1/SubmissionQueue.java
+++ b/Problem1/SubmissionQueue.java
@@ -5,16 +5,16 @@
 */
 
 
-import java.util.Queue;
-import java.util.concurrent.PriorityBlockingQueue;
+import java.util.LinkedList;
+import java.util.NoSuchElementException;
 
 public class SubmissionQueue
 {
-	private PriorityBlockingQueue<Submission> internalQueue;
+	private LinkedList<Submission> internalQueue;
     private static SubmissionQueue queue;
 
     private SubmissionQueue(){
-        internalQueue = new PriorityBlockingQueue<Submission>();
+        internalQueue = new LinkedList<Submission>();
 
     }
 
@@ -25,22 +25,29 @@ public class SubmissionQueue
         return queue;
     }
 
-	public boolean add(Submission s){
-		return internalQueue.add(s);
+	public synchronized boolean add(Submission submission){
+		System.out.println("Adding Submission with id " + submission.getId());
+        return internalQueue.add(submission);
 	}
 
     public boolean process() {
+        Submission target = getNextSubmission();
+        if (target != null){
+            System.out.println("Processing Submission with id " + target.getId());
+            return true;
+        }
+        return false;
+    }
+
+    private synchronized Submission getNextSubmission(){
         Submission target;
         try {
-            target = internalQueue.take();
-        } catch (InterruptedException e) {
-            //oh no
-            System.err.println(e);
-            return false;
+            target = internalQueue.remove();
+            return target;
         }
-
-        //do some stuff to target
-
-        return (target != null);
+        catch(NoSuchElementException e){
+            System.err.println("Caught NoSuchElementException: " + e.getMessage());
+            return null;
+        }
     }
 }


### PR DESCRIPTION
This is a working implementation of LinkedList used as a FIFO queue. The `add(Submission submission)` method and private `getNextSubmission()` methods are synchronized which will stop the `internalQueue` from being accessed by multiple threads at the same time.

The driver is a simple implementation that creates 4 submissions, then queues them, then processes them. When you run it, you can see the IDs are queued and processed in the same order.
