### PR TITLE
queue now FIFO

### DIFF
--- a/Problem1/SubmissionQueue.java
+++ b/Problem1/SubmissionQueue.java
@@ -6,11 +6,11 @@
 
 
 import java.util.Queue;
-import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 public class SubmissionQueue
 {
-	private PriorityBlockingQueue<Submission> internalQueue;
+	private LinkedBlockingQueue<Submission> internalQueue;
 	public boolean add(Submission s){
 		return internalQueue.add(s);
 	}
@@ -27,6 +27,6 @@ public class SubmissionQueue
 		return true;
 	}
 	public SubmissionQueue(){
-		internalQueue = new PriorityBlockingQueue<Submission>();
+		internalQueue = new LinkedBlockingQueue<Submission>();
 	}
 }


### PR DESCRIPTION
LinkedBlockingQueue is a linked-list-based implementation of Java's AbstractQueue that, unlike PriorityBlockingQueue, complies with first-in-first-out behavior. It's also still thread-safe.
